### PR TITLE
Potential fix for code scanning alert no. 2: Use of externally-controlled format string

### DIFF
--- a/kubernetes-mcp-server/src/index.js
+++ b/kubernetes-mcp-server/src/index.js
@@ -276,7 +276,7 @@ app.post("/api/approvals/:id/approve", async (req, res) => {
     });
     
   } catch (error) {
-    console.error(`❌ Approval ${id} failed:`, error.message);
+    console.error(`❌ Approval ${id} failed: ${error.message}`);
     res.status(500).json({ error: error.message });
   }
 });


### PR DESCRIPTION
Potential fix for [https://github.com/avinfinity/agentic-observability/security/code-scanning/2](https://github.com/avinfinity/agentic-observability/security/code-scanning/2)

The best way to address this issue is to ensure the user-supplied ID is not treated as a format string, i.e., that it cannot inject formatting directives such as `%s`, which cause subsequent arguments to be formatted in unpredictable ways. This can be done by using a single string argument (with proper sanitization if necessary) or by using a fixed format string with placeholder(s) such as `%s` for inserting the user-controlled values.

For this code, the safest and simplest approach is to restructure the `console.error` call to make the entire message a single string, interpolating `id` and `error.message` either in a template literal, or else by using a format string with explicit `%s` specifiers. Both avoid the risk of the user-provided `id` being interpreted as a format string. For consistency with the rest of the file and clarity, it is preferable to use a template string and pass a single argument to `console.error`.

Only one code region—line 279 in `kubernetes-mcp-server/src/index.js`—needs to be changed. No additional packages or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
