### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/kubernetes-mcp-server/package.json
+++ b/kubernetes-mcp-server/package.json
@@ -22,7 +22,7 @@
     "express": "^4.18.2",
     "cors": "^2.8.5",
     "uuid": "^10.0.0",
-    "node-fetch": "^3.3.0"
+    "node-fetch": "^3.3.0",
+    "express-rate-limit": "^8.2.1"
   }
 }
-

--- a/kubernetes-mcp-server/src/index.js
+++ b/kubernetes-mcp-server/src/index.js
@@ -11,6 +11,7 @@ import express from "express";
 import cors from "cors";
 import { v4 as uuidv4 } from "uuid";
 import fetch from "node-fetch";
+import rateLimit from "express-rate-limit";
 
 // Backend webhook URL for learning feedback
 // Use 127.0.0.1 instead of localhost to force IPv4 (avoid IPv6 connection issues)
@@ -198,10 +199,16 @@ app.use(cors());
 app.use(express.json());
 app.use(express.static("src"));
 
+// Apply a rate limiter to routes serving files.
+const fileLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+
 const APPROVAL_PORT = 3100;
 
 // Serve approval UI
-app.get("/", (req, res) => {
+app.get("/", fileLimiter, (req, res) => {
   res.sendFile("approval-ui.html", { root: "src" });
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/avinfinity/agentic-observability/security/code-scanning/1](https://github.com/avinfinity/agentic-observability/security/code-scanning/1)

To fix this vulnerability, a rate-limiting middleware should be added to the Express app or specifically to the affected routes. The best and most common solution is to use the `express-rate-limit` package to limit the number of requests per client (by IP address) in a given time window. This will mitigate the risk of resource exhaustion from too many simultaneous file-serving requests. 

The fix requires these steps:
- Import the `express-rate-limit` package.
- Create a rate limiter instance with sensible defaults (e.g., 100 requests per 15 minutes).
- Apply this rate limiter to the route serving the file system access (or to all app routes, if preferred).

This change should be done in `kubernetes-mcp-server/src/index.js`, above or with the definition of the relevant route (`app.get("/", ...)`). The only new dependency required is `express-rate-limit`, which should be added at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
